### PR TITLE
Fix DMXData string formatting bug

### DIFF
--- a/backend/internal/domain/model/dmx.go
+++ b/backend/internal/domain/model/dmx.go
@@ -129,7 +129,7 @@ func (d *DMXData) GetChannelRange(startChannel, endChannel int) ([]uint8, error)
 
 // String DMXDataの文字列表現
 func (d *DMXData) String() string {
-	return fmt.Sprintf("DMX[Universe:%d, Seq:%d, Length:%d",
+	return fmt.Sprintf("DMX[Universe:%d, Seq:%d, Length:%d]",
 		d.GetUniverse(), d.Sequence, d.Length)
 }
 

--- a/backend/internal/domain/model/dmx_test.go
+++ b/backend/internal/domain/model/dmx_test.go
@@ -225,7 +225,6 @@ func TestDMXData_String(t *testing.T) {
 	}
 
 	str := dmx.String()
-	assert.Contains(t, str, "Universe:517") // 2*256+5 = 517
-	assert.Contains(t, str, "Seq:10")
-	assert.Contains(t, str, "Length:100")
+	expected := "DMX[Universe:517, Seq:10, Length:100]" // 2*256+5 = 517
+	assert.Equal(t, expected, str)
 }


### PR DESCRIPTION
## Summary
- fix missing closing bracket in DMXData string representation
- tighten DMXData string test to assert full output

## Testing
- `make lint` *(fails: internal/app/app.go:25:12: pattern embed_static/assets/*: no matching files found)*
- `make test` *(fails: frontend test src/App.test.tsx > App > 現在時刻が正しく表示される)*
- `go test ./internal/domain/model -run TestDMXData_String -v`

------
https://chatgpt.com/codex/tasks/task_e_689ce0663d048329a8142ea6c98f11bd