### PR TITLE
feat: サーバーメッセージの最大数を200に制限し、テストを追加

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -57,6 +57,12 @@ export default [
         CustomEvent: 'readonly',
         EventListener: 'readonly',
         HTMLSelectElement: 'readonly',
+        describe: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        vi: 'readonly',
       },
     },
     settings: {

--- a/frontend/src/stores/artNetStore.test.ts
+++ b/frontend/src/stores/artNetStore.test.ts
@@ -1,0 +1,48 @@
+import { act } from '@testing-library/react'
+import { describe, test, expect, beforeEach } from 'vitest'
+import { useArtNetStore } from './artNetStore'
+import type { ServerMessage } from '@/types/websocket'
+
+// Helper to get current state
+const getState = () => useArtNetStore.getState()
+
+const makeMessage = (i: number): ServerMessage => ({
+  Type: 'info',
+  Message: `msg-${i}`,
+  Timestamp: i, // strictly increasing
+})
+
+describe('artNetStore serverMessages cap', () => {
+  beforeEach(() => {
+    act(() => {
+      getState().clearData()
+    })
+  })
+
+  test('keeps messages in order and caps at 200 newest', () => {
+    act(() => {
+      for (let i = 1; i <= 205; i++) {
+        getState().addServerMessage(makeMessage(i))
+      }
+    })
+
+    const { serverMessages } = getState()
+    expect(serverMessages.length).toBe(200)
+    // Should contain messages 6..205
+    expect(serverMessages[0].Message).toBe('msg-6')
+    expect(serverMessages[0].Timestamp).toBe(6)
+    expect(serverMessages[199].Message).toBe('msg-205')
+  })
+
+  test('ignores duplicate timestamp at tail', () => {
+    act(() => {
+      getState().addServerMessage(makeMessage(1))
+      getState().addServerMessage(makeMessage(1)) // duplicate timestamp
+      getState().addServerMessage(makeMessage(2))
+    })
+    const { serverMessages } = getState()
+    expect(serverMessages.length).toBe(2)
+    expect(serverMessages[0].Timestamp).toBe(1)
+    expect(serverMessages[1].Timestamp).toBe(2)
+  })
+})

--- a/frontend/src/stores/artNetStore.ts
+++ b/frontend/src/stores/artNetStore.ts
@@ -44,10 +44,14 @@ export const useArtNetStore = create<ArtNetStore>(set => ({
   addServerMessage: message => {
     set(state => {
       const prevMessages = state.serverMessages
+      const MAX_SERVER_MESSAGES = 200
       if (prevMessages.length > 0 && prevMessages[prevMessages.length - 1].Timestamp === message.Timestamp) {
         return { serverMessages: prevMessages }
       }
-      return { serverMessages: [...prevMessages, message] }
+      const appended = [...prevMessages, message]
+      const sliced =
+        appended.length > MAX_SERVER_MESSAGES ? appended.slice(appended.length - MAX_SERVER_MESSAGES) : appended
+      return { serverMessages: sliced }
     })
   },
 

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,5 +1,13 @@
 {
-  "include": ["src/**/*", "src/**/*.tsx", "src/types/**/*.d.ts", "css/**/*", "env.d.ts"],
+  "include": [
+    "src/**/*",
+    "src/**/*.tsx",
+    "src/types/**/*.d.ts",
+    "css/**/*",
+    "env.d.ts",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ],
   "exclude": ["node_modules", "../priv/static"],
   "compilerOptions": {
     "strict": true,


### PR DESCRIPTION
This pull request adds a cap to the number of server messages stored in `artNetStore` and introduces corresponding unit tests. It also updates configuration files to ensure test files are properly recognized and testing globals are defined.

**Store logic improvements:**

* Added a cap to `serverMessages` in `useArtNetStore` so only the 200 newest messages are kept, and duplicate timestamps at the tail are ignored. (`frontend/src/stores/artNetStore.ts`)

**Testing and test infrastructure:**

* Added a new test file `artNetStore.test.ts` with tests verifying the message cap and duplicate handling in `artNetStore`. (`frontend/src/stores/artNetStore.test.ts`)
* Updated `tsconfig.json` to include `.test.ts` and `.test.tsx` files for TypeScript compilation. (`frontend/tsconfig.json`)
* Declared Vitest globals as read-only in the ESLint config to prevent linting errors in test files. (`frontend/eslint.config.js`)